### PR TITLE
PLATUI-2886: Replace slf4j-simple with logback-classic

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "HMRC-open-artefacts-maven2" at "https://open.artefacts.tax.service.gov.uk/maven2"
+resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
   Resolver.ivyStylePatterns
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,6 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.4")
 
 addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.16.2")

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "$name$",
     version := "0.1.0",
-    scalaVersion := "2.13.12",
+    scalaVersion := "2.13.13",
     libraryDependencies ++= Dependencies.test,
     (Compile / compile) := ((Compile / compile) dependsOn (Compile / scalafmtSbtCheck, Compile / scalafmtCheckAll)).value
   )

--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -3,10 +3,10 @@ import sbt.*
 object Dependencies {
 
   val test: Seq[ModuleID] = Seq(
-    "com.vladsch.flexmark" % "flexmark-all"   % "0.64.8" % Test,
-    "org.scalatest"       %% "scalatest"      % "3.2.18" % Test,
-    "org.slf4j"            % "slf4j-simple"   % "2.0.9"  % Test,
-    "uk.gov.hmrc"         %% "ui-test-runner" % "0.19.0" % Test
+    "ch.qos.logback"       % "logback-classic" % "1.5.1"  % Test,
+    "com.vladsch.flexmark" % "flexmark-all"    % "0.64.8" % Test,
+    "org.scalatest"       %% "scalatest"       % "3.2.18" % Test,
+    "uk.gov.hmrc"         %% "ui-test-runner"  % "0.20.0" % Test
   )
 
 }

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.8

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "HMRC-open-artefacts-maven2" at "https://open.artefacts.tax.service.gov.uk/maven2"
+resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
   Resolver.ivyStylePatterns
 )
@@ -7,6 +7,6 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.4")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-test-report" % "0.22.0")


### PR DESCRIPTION
Template:
- [Replace slf4j-simple with logback-classic version 1.5.1](https://github.com/hmrc/platform-test-ui-journey-tests-template.g8/commit/fd9760a987fe58e9aba9fa58fb83d60855326f09)
- [Update sbt-updates version to 0.6.4](https://github.com/hmrc/platform-test-ui-journey-tests-template.g8/commit/fa8d59b02c4befb182d9f0d19f1d342a4ab0aef6)
- [Update sbt version to 1.9.8](https://github.com/hmrc/platform-test-ui-journey-tests-template.g8/commit/304182cfad7d636bf481a5fc56470eb100bbd063)
- [Update scala version to 2.13.13](https://github.com/hmrc/platform-test-ui-journey-tests-template.g8/commit/d80b2fe6a1eef4835ddb11b811ba69d4e9182902)

Project:
- [Update sbt-updates version to 0.6.4](https://github.com/hmrc/platform-test-ui-journey-tests-template.g8/commit/0bc784a616b1ac41356dec8fddd5983882701090)
- [Update sbt version to 1.9.8](https://github.com/hmrc/platform-test-ui-journey-tests-template.g8/commit/3940526bc9f9505d93ab1d4571a870f42762e9d5)
- [Update maven repository resolver](https://github.com/hmrc/platform-test-ui-journey-tests-template.g8/pull/4/commits/f0718a87408797a59acdb7de39f9d2013f5b45de)