### PR TITLE
PLATUI-2962: Update ui-test-runner to version 0.29.0

### DIFF
--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     "ch.qos.logback"       % "logback-classic" % "1.5.4"  % Test,
     "com.vladsch.flexmark" % "flexmark-all"    % "0.64.8" % Test,
     "org.scalatest"       %% "scalatest"       % "3.2.18" % Test,
-    "uk.gov.hmrc"         %% "ui-test-runner"  % "0.28.0" % Test
+    "uk.gov.hmrc"         %% "ui-test-runner"  % "0.29.0" % Test
   )
 
 }


### PR DESCRIPTION
- [Update ui-test-runner to version 0.29.0](https://github.com/hmrc/platform-test-ui-journey-tests-template.g8/commit/c5e2d68a536e1c5a22afaf5077793d3f1867b695)