### PR TITLE
PLATUI-3057: Bump ui-test-runner to 0.30.0

### DIFF
--- a/src/main/g8/project/Dependencies.scala
+++ b/src/main/g8/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     "ch.qos.logback"       % "logback-classic" % "1.5.4"  % Test,
     "com.vladsch.flexmark" % "flexmark-all"    % "0.64.8" % Test,
     "org.scalatest"       %% "scalatest"       % "3.2.18" % Test,
-    "uk.gov.hmrc"         %% "ui-test-runner"  % "0.29.0" % Test
+    "uk.gov.hmrc"         %% "ui-test-runner"  % "0.30.0" % Test
   )
 
 }


### PR DESCRIPTION
- adds latest version of ui-test-runner which includes a re-packed accessibility assessment extension for Chrome and Edge browsers